### PR TITLE
Add DoneMail register mail provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
++ [新增] 注册账号新增 DoneMail 邮箱来源，支持通过公开 API Key 读取指定收件地址的验证码邮件。
+
 ## 2.6.2 - 2026-07-08
 
 + [修复] OpenAI 注册流程 `create_account` 阶段的 `registration_disallowed` 错误，补齐 Turnstile SO Token 生成与双 Sentinel header 发送，对齐官方 SDK 5000ms 采集行为，预计成功率从 0% 提升至 50% 左右。

--- a/services/register/mail_provider.py
+++ b/services/register/mail_provider.py
@@ -1214,6 +1214,112 @@ class GptMailProvider(BaseMailProvider):
         self.session.close()
 
 
+class DoneMailProvider(BaseMailProvider):
+    name = "donemail"
+
+    def __init__(self, entry: dict, conf: dict):
+        super().__init__(conf, str(entry.get("provider_ref") or ""))
+        api_base = str(entry["api_base"]).rstrip("/")
+        for suffix in ("/api/overview", "/api/view-mails", "/api"):
+            if api_base.endswith(suffix):
+                api_base = api_base[: -len(suffix)].rstrip("/")
+                break
+        self.api_base = api_base
+        self.admin_key = str(entry.get("admin_key") or entry.get("admin_password") or entry.get("api_key") or "").strip()
+        self.domain = _normalize_string_list(entry.get("domain") or entry.get("default_domain"))
+        self.email_prefix = str(entry.get("email_prefix") or "").strip()
+        self.message_limit = max(1, min(50, int(entry.get("message_limit") or 20)))
+        self.session = _create_session(conf)
+        self.session.headers.update({
+            "User-Agent": conf["user_agent"],
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "X-Admin-Key": self.admin_key,
+        })
+
+    def _request(self, method: str, path: str, params: dict | None = None, payload: dict | None = None, expected: tuple[int, ...] = (200,)):
+        if not self.admin_key:
+            raise RuntimeError("DoneMail 缺少 X-Admin-Key")
+        resp = self.session.request(
+            method.upper(),
+            f"{self.api_base}{path}",
+            params=params,
+            json=payload,
+            timeout=self.conf["request_timeout"],
+            verify=False,
+        )
+        if resp.status_code not in expected:
+            raise RuntimeError(f"DoneMail 请求失败: {method} {path}, HTTP {resp.status_code}, body={resp.text[:300]}")
+        data = resp.json()
+        if isinstance(data, dict) and data.get("ok") is False:
+            error = data.get("error") if isinstance(data.get("error"), dict) else {}
+            message = error.get("message") or error.get("code") or "DoneMail 返回失败"
+            raise RuntimeError(f"DoneMail 请求失败: {message}")
+        return data
+
+    @staticmethod
+    def _items(data: Any) -> list:
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            items = data.get("data") or data.get("mails") or data.get("messages") or data.get("items") or []
+            return items if isinstance(items, list) else []
+        return []
+
+    def _resolve_address(self, username: str | None = None) -> str:
+        if username and "@" in username:
+            return username.strip()
+        if not self.domain:
+            raise RuntimeError("DoneMail 需要至少配置一个 domain")
+        local_part = username or (f"{self.email_prefix}_{_random_mailbox_name()}" if self.email_prefix else _random_mailbox_name())
+        return f"{local_part}@{_next_domain(self.domain)}"
+
+    def create_mailbox(self, username: str | None = None) -> dict[str, Any]:
+        address = self._resolve_address(username)
+        return {"provider": self.name, "provider_ref": self.provider_ref, "address": address}
+
+    def get_existing_mailbox(self, email: str) -> dict[str, Any]:
+        address = str(email or "").strip()
+        if not address:
+            raise RuntimeError("DoneMail 缺少 email")
+        return {"provider": self.name, "provider_ref": self.provider_ref, "address": address}
+
+    def fetch_latest_message(self, mailbox: dict[str, Any]) -> dict[str, Any] | None:
+        address = str(mailbox.get("address") or "").strip()
+        if not address:
+            raise RuntimeError("DoneMail 缺少 address")
+        data = self._request("GET", "/api/mails", params={"limit": self.message_limit, "to": address})
+        messages = [item for item in self._items(data) if isinstance(item, dict) and _message_matches_email(item, address)]
+        if not messages:
+            return None
+        item = max(
+            messages,
+            key=lambda value: (
+                (_parse_received_at(value.get("receivedAt") or value.get("received_at") or value.get("createdAt") or value.get("created_at") or value.get("date") or value.get("timestamp")) or datetime.fromtimestamp(0, tz=timezone.utc)).timestamp(),
+                str(value.get("id") or value.get("_id") or ""),
+            ),
+        )
+        text_content, html_content = _extract_content(item)
+        sender = item.get("from") or item.get("sender") or ""
+        if isinstance(sender, dict):
+            sender = sender.get("address") or sender.get("email") or sender.get("name") or ""
+        return {
+            "provider": self.name,
+            "mailbox": address,
+            "message_id": str(item.get("id") or item.get("_id") or item.get("messageId") or ""),
+            "subject": str(item.get("subject") or ""),
+            "sender": str(sender),
+            "text_content": text_content or str(item.get("preview") or ""),
+            "html_content": html_content,
+            "received_at": _parse_received_at(item.get("receivedAt") or item.get("received_at") or item.get("createdAt") or item.get("created_at") or item.get("date") or item.get("timestamp")),
+            "to": item.get("to") or item.get("toEmail") or item.get("mailTo"),
+            "raw": item,
+        }
+
+    def close(self) -> None:
+        self.session.close()
+
+
 class MoEmailProvider(BaseMailProvider):
     name = "moemail"
 
@@ -2048,6 +2154,8 @@ def _create_provider(mail_config: dict, provider: str = "", provider_ref: str = 
         return DuckMailProvider(entry, conf)
     if entry["type"] == "gptmail":
         return GptMailProvider(entry, conf)
+    if entry["type"] in {"donemail", "done_mail"}:
+        return DoneMailProvider(entry, conf)
     if entry["type"] == "moemail":
         return MoEmailProvider(entry, conf)
     if entry["type"] == "inbucket":

--- a/web-vue/src/api/register.ts
+++ b/web-vue/src/api/register.ts
@@ -25,6 +25,7 @@ export type RegisterProvider = {
   label?: string
   api_base?: string
   api_key?: string
+  admin_key?: string
   admin_email?: string
   admin_password?: string
   ddg_token?: string

--- a/web-vue/src/views/Register.vue
+++ b/web-vue/src/views/Register.vue
@@ -286,6 +286,16 @@
                       <Input v-model.trim="provider.admin_email" block :disabled="registerConfig.enabled" />
                     </label>
 
+                    <label v-if="providerType(provider) === 'donemail'" class="register-field">
+                      <span class="register-label">Admin Key</span>
+                      <Input
+                        v-model.trim="provider.admin_key"
+                        block
+                        root-class="font-mono"
+                        :disabled="registerConfig.enabled"
+                      />
+                    </label>
+
                     <label v-if="providerUsesAdminPassword(provider)" class="register-field">
                       <span class="register-label">{{ providerType(provider) === 'ddg_mail' ? 'CF Admin Password' : 'Admin Password' }}</span>
                       <Input
@@ -316,7 +326,7 @@
                       />
                     </label>
 
-                    <label v-if="providerType(provider) === 'cloudmail_gen'" class="register-field">
+                    <label v-if="providerType(provider) === 'cloudmail_gen' || providerType(provider) === 'donemail'" class="register-field">
                       <span class="register-label">邮箱前缀</span>
                       <Input
                         v-model.trim="provider.email_prefix"
@@ -335,6 +345,18 @@
                         block
                         :disabled="registerConfig.enabled"
                         placeholder="0 表示服务默认"
+                      />
+                    </label>
+
+                    <label v-if="providerType(provider) === 'donemail'" class="register-field">
+                      <span class="register-label">读取邮件数</span>
+                      <Input
+                        v-model.number="provider.message_limit"
+                        type="number"
+                        min="1"
+                        max="50"
+                        block
+                        :disabled="registerConfig.enabled"
                       />
                     </label>
 
@@ -792,6 +814,7 @@ const providerTypeOptions = [
   { value: 'inbucket', label: 'Inbucket' },
   { value: 'duckmail', label: 'DuckMail' },
   { value: 'gptmail', label: 'GPTMail' },
+  { value: 'donemail', label: 'DoneMail' },
   { value: 'yyds_mail', label: 'YYDS Mail' },
   { value: 'ddg_mail', label: 'DDG + CF 收件箱' },
   { value: 'outlook_token', label: 'Microsoft 邮箱凭据池' },
@@ -833,6 +856,7 @@ const providerTypeKeys: Record<string, string[]> = {
   inbucket: ['api_base', 'domain', 'random_subdomain'],
   duckmail: ['api_key', 'default_domain'],
   gptmail: ['key_mode', 'api_key', 'default_domain', 'local_compose'],
+  donemail: ['api_base', 'admin_key', 'domain', 'email_prefix', 'message_limit'],
   yyds_mail: ['api_base', 'api_key', 'domain', 'subdomain', 'wildcard'],
   ddg_mail: ['api_base', 'ddg_token', 'cf_inbox_jwt', 'admin_password', 'cf_api_key', 'cf_auth_mode', 'cf_create_path', 'cf_messages_path'],
   outlook_token: ['mailboxes', 'mode', 'imap_host', 'message_limit', 'alias_enabled', 'alias_per_email', 'alias_prefix', 'alias_include_original'],
@@ -954,6 +978,8 @@ function defaultProvider(type = 'cloudmail_gen'): RegisterProvider {
       return { ...base, api_key: '', default_domain: 'duckmail.sbs' }
     case 'gptmail':
       return { ...base, key_mode: 'public', api_key: '', default_domain: '', local_compose: false }
+    case 'donemail':
+      return { ...base, api_base: '', admin_key: '', domain: [], email_prefix: '', message_limit: 20 }
     case 'yyds_mail':
       return { ...base, api_base: 'https://maliapi.215.im/v1', api_key: '', domain: [], subdomain: '', wildcard: false }
     case 'ddg_mail':
@@ -1091,6 +1117,11 @@ function providerRequirementMessages(provider: RegisterProvider) {
       requireValue(provider.admin_password, 'Admin Password')
       requireList(provider.domain, '域名')
       break
+    case 'donemail':
+      requireValue(provider.api_base, 'API Base')
+      requireValue(provider.admin_key, 'Admin Key')
+      requireList(provider.domain, '域名')
+      break
     case 'moemail':
       requireValue(provider.api_base, 'API Base')
       requireValue(provider.api_key, 'API Key')
@@ -1143,7 +1174,7 @@ function updateProviderField(index: number, key: string, value: unknown) {
 }
 
 function providerUsesApiBase(provider: RegisterProvider) {
-  return ['cloudmail_gen', 'cloudflare_temp_email', 'moemail', 'inbucket', 'yyds_mail', 'ddg_mail'].includes(providerType(provider))
+  return ['cloudmail_gen', 'cloudflare_temp_email', 'moemail', 'inbucket', 'yyds_mail', 'ddg_mail', 'donemail'].includes(providerType(provider))
 }
 
 function providerUsesApiKey(provider: RegisterProvider) {
@@ -1163,18 +1194,20 @@ function providerUsesDefaultDomain(provider: RegisterProvider) {
 }
 
 function providerUsesDomainList(provider: RegisterProvider) {
-  return ['cloudmail_gen', 'tempmail_lol', 'cloudflare_temp_email', 'moemail', 'inbucket', 'yyds_mail'].includes(providerType(provider))
+  return ['cloudmail_gen', 'tempmail_lol', 'cloudflare_temp_email', 'moemail', 'inbucket', 'yyds_mail', 'donemail'].includes(providerType(provider))
 }
 
 function apiBaseLabel(provider: RegisterProvider) {
   const type = providerType(provider)
   if (type === 'cloudmail_gen') return 'CloudMail URL'
   if (type === 'ddg_mail') return 'CF API Base'
+  if (type === 'donemail') return 'DoneMail URL'
   return 'API Base'
 }
 
 function apiBasePlaceholder(provider: RegisterProvider) {
   const type = providerType(provider)
+  if (type === 'donemail') return 'https://sow.us.kg'
   if (type === 'yyds_mail') return 'https://maliapi.215.im/v1'
   return ''
 }
@@ -1194,6 +1227,7 @@ function domainPlaceholder(provider: RegisterProvider) {
   if (type === 'moemail') return '每行一个域名'
   if (type === 'tempmail_lol') return '每行一个域名，可留空使用服务默认'
   if (type === 'yyds_mail') return '每行一个域名，可留空'
+  if (type === 'donemail') return '每行一个 DoneMail 已接收域名'
   return '每行一个域名'
 }
 


### PR DESCRIPTION
## Summary

- add DoneMail as a registration mail provider
- query DoneMail public API with `X-Admin-Key` and filter messages by recipient address
- expose DoneMail configuration in the register page

## Test

- `python -m py_compile ./services/register/mail_provider.py`
- `npm ci`
- `npm run build`
