### PR TITLE
feat(images): 支持 Gallery 单张图片手动 Push 到 GenBox

### DIFF
--- a/api/gallery_contract.py
+++ b/api/gallery_contract.py
@@ -8,6 +8,15 @@ from pydantic import BaseModel, ConfigDict, Field
 GalleryMediaType = Literal["image"]
 GalleryMediaFilter = Literal["all", "image"]
 GalleryStorage = Literal["local", "webdav", "both"]
+GenBoxPushStatus = Literal["imported", "already-imported", "duplicate-local"]
+
+
+class GalleryGenBoxPushState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: GenBoxPushStatus
+    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    updated_at: str
 
 
 class GalleryRow(BaseModel):
@@ -32,6 +41,18 @@ class GalleryRow(BaseModel):
     available: bool
     width: int | None = Field(default=None, ge=1)
     height: int | None = Field(default=None, ge=1)
+    genbox_push: GalleryGenBoxPushState | None = None
+
+
+class GalleryGenBoxPushRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    path: str = Field(min_length=1, max_length=1024)
+
+
+class GalleryGenBoxPushResult(GalleryGenBoxPushState):
+    path: str
+    source_retained: bool = True
 
 
 class GalleryMediaFacets(BaseModel):

--- a/api/system.py
+++ b/api/system.py
@@ -12,6 +12,8 @@ from api.gallery_contract import (
     GalleryCleanupResult,
     GalleryCleanupTargetResult,
     GalleryCompressResult,
+    GalleryGenBoxPushRequest,
+    GalleryGenBoxPushResult,
     GalleryMediaFilter,
     GalleryPage,
 )
@@ -45,6 +47,7 @@ from services.gallery_view import (
     gallery_cleanup_target_result,
     gallery_compress_result,
 )
+from services.genbox_push_service import push_gallery_image
 from services.image_service import (
     cleanup_expired_images,
     compress_images,
@@ -293,6 +296,14 @@ def create_router(app_version: str) -> APIRouter:
     async def download_single_image_endpoint(image_path: str, authorization: str | None = Header(default=None)):
         require_admin(authorization)
         return get_image_download_response(image_path)
+
+    @router.post("/api/images/genbox-push", response_model=GalleryGenBoxPushResult)
+    async def push_image_to_genbox(
+        body: GalleryGenBoxPushRequest,
+        authorization: str | None = Header(default=None),
+    ):
+        require_admin(authorization)
+        return await run_in_threadpool(push_gallery_image, body.path)
 
     @router.get("/api/logs", response_model=CallSummaryPage)
     async def get_logs(

--- a/contracts/settings.py
+++ b/contracts/settings.py
@@ -73,6 +73,22 @@ class ImageStoragePatch(_ImageStorageFields):
     pass
 
 
+class _GenBoxPushFields(_StrictModel):
+    enabled: bool = False
+    base_url: str = ""
+    source_id: str = ""
+    push_key: str = ""
+    timeout_secs: int = Field(default=20, ge=5, le=120)
+
+
+class GenBoxPushSettings(_GenBoxPushFields):
+    has_push_key: bool = False
+
+
+class GenBoxPushPatch(_GenBoxPushFields):
+    clear_push_key: bool = False
+
+
 class BackupIncludeSettings(_StrictModel):
     image_tasks: bool = True
     editable_files: bool = True
@@ -185,6 +201,7 @@ class _SettingsEditableFields(_StrictModel):
     sensitive_words: list[str] = Field(default_factory=list)
     ai_review: AIReviewPatch = Field(default_factory=AIReviewPatch)
     image_storage: ImageStoragePatch = Field(default_factory=ImageStoragePatch)
+    genbox_push: GenBoxPushPatch = Field(default_factory=GenBoxPushPatch)
     backup: BackupPatch = Field(default_factory=BackupPatch)
     third_party_apps: ThirdPartyAppsSettings = Field(default_factory=ThirdPartyAppsSettings)
 
@@ -198,6 +215,7 @@ class SettingsValues(_SettingsEditableFields):
     proxy_runtime: ProxyRuntimeSettings = Field(default_factory=ProxyRuntimeSettings)
     ai_review: AIReviewSettings = Field(default_factory=AIReviewSettings)
     image_storage: ImageStorageSettings = Field(default_factory=ImageStorageSettings)
+    genbox_push: GenBoxPushSettings = Field(default_factory=GenBoxPushSettings)
     backup: BackupSettings = Field(default_factory=BackupSettings)
 
 

--- a/services/config.py
+++ b/services/config.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import copy
 import os
+import re
 import threading
 from time import monotonic
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 from contracts.settings_specification import (
     normalize_float_setting,
@@ -47,6 +49,14 @@ DEFAULT_IMAGE_STORAGE = {
     "webdav_password": "",
     "webdav_root_path": "chatgpt2api/images",
     "public_base_url": "",
+}
+
+DEFAULT_GENBOX_PUSH = {
+    "enabled": False,
+    "base_url": "",
+    "source_id": "",
+    "push_key": "",
+    "timeout_secs": 20,
 }
 
 DEFAULT_CHAT_COMPLETION_CACHE = {
@@ -172,6 +182,39 @@ def _normalize_image_storage_settings(value: object) -> dict[str, object]:
         "webdav_password": str(source.get("webdav_password") or "").strip(),
         "webdav_root_path": root_path or str(DEFAULT_IMAGE_STORAGE["webdav_root_path"]),
         "public_base_url": str(source.get("public_base_url") or "").strip().rstrip("/"),
+    })
+    return normalized
+
+
+def _normalize_genbox_base_url(value: object) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    parsed = urlsplit(raw)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return ""
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        return ""
+    if parsed.path.rstrip("/") not in {"", "/api/sync/push"}:
+        return ""
+    return urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+
+
+def _normalize_genbox_push_settings(value: object) -> dict[str, object]:
+    source = value if isinstance(value, dict) else {}
+    try:
+        timeout = int(source.get("timeout_secs") or DEFAULT_GENBOX_PUSH["timeout_secs"])
+    except (TypeError, ValueError):
+        timeout = int(DEFAULT_GENBOX_PUSH["timeout_secs"])
+    normalized = copy.deepcopy(source)
+    normalized.pop("has_push_key", None)
+    normalized.pop("clear_push_key", None)
+    normalized.update({
+        "enabled": _normalize_bool(source.get("enabled"), False),
+        "base_url": _normalize_genbox_base_url(source.get("base_url")),
+        "source_id": str(source.get("source_id") or "").strip(),
+        "push_key": str(source.get("push_key") or "").strip(),
+        "timeout_secs": max(5, min(120, timeout)),
     })
     return normalized
 
@@ -348,6 +391,17 @@ def _validate_image_storage_settings(settings: dict[str, object]) -> None:
         raise ValueError("启用 WebDAV 图片存储后必须填写 WebDAV URL")
     if not str(settings.get("webdav_password") or "").strip():
         raise ValueError("启用 WebDAV 图片存储后必须填写 WebDAV 密码")
+
+
+def _validate_genbox_push_settings(settings: dict[str, object]) -> None:
+    if not _normalize_bool(settings.get("enabled"), False):
+        return
+    if not _normalize_genbox_base_url(settings.get("base_url")):
+        raise ValueError("GenBox Push requires a valid HTTP(S) base URL")
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}", str(settings.get("source_id") or "").strip()):
+        raise ValueError("GenBox Push source ID is invalid")
+    if not str(settings.get("push_key") or "").strip():
+        raise ValueError("GenBox Push requires a Push Key")
 
 
 def _normalize_auth_key(value: object) -> str:
@@ -650,6 +704,7 @@ class ConfigStore:
             data["global_system_prompt"] = self.global_system_prompt
             data["backup"] = self.get_backup_settings()
             data["image_storage"] = self.get_image_storage_settings()
+            data["genbox_push"] = self.get_genbox_push_settings()
             data["chat_completion_cache"] = self.get_chat_completion_cache_settings()
             data["proxy_runtime"] = self.get_public_proxy_runtime_settings()
             data["fallback_proxy"] = self.get_proxy_fallback_settings()
@@ -734,6 +789,9 @@ class ConfigStore:
             if "image_storage" in updates:
                 updates["image_storage"] = _normalize_image_storage_settings(updates.get("image_storage"))
                 _validate_image_storage_settings(updates["image_storage"])
+            if "genbox_push" in updates:
+                updates["genbox_push"] = _normalize_genbox_push_settings(updates.get("genbox_push"))
+                _validate_genbox_push_settings(updates["genbox_push"])
             if "chat_completion_cache" in updates:
                 updates["chat_completion_cache"] = _normalize_chat_completion_cache_settings(
                     updates.get("chat_completion_cache")
@@ -761,6 +819,9 @@ class ConfigStore:
 
     def get_image_storage_settings(self) -> dict[str, object]:
         return _normalize_image_storage_settings(self.data.get("image_storage"))
+
+    def get_genbox_push_settings(self) -> dict[str, object]:
+        return _normalize_genbox_push_settings(self.data.get("genbox_push"))
 
     def get_chat_completion_cache_settings(self) -> dict[str, object]:
         return _normalize_chat_completion_cache_settings(self.data.get("chat_completion_cache"))

--- a/services/gallery_view.py
+++ b/services/gallery_view.py
@@ -67,6 +67,19 @@ def _thumbnail_url(base_url: str, path: str) -> str:
     return f"{base_url.rstrip('/')}/image-thumbnails/{path}"
 
 
+def _genbox_push_state(value: object) -> dict[str, str] | None:
+    if not isinstance(value, Mapping):
+        return None
+    status = _text(value.get("status"))
+    sha256 = _text(value.get("sha256")).lower()
+    updated_at = _text(value.get("updated_at"))
+    if status not in {"imported", "already-imported", "duplicate-local"}:
+        return None
+    if len(sha256) != 64 or any(char not in "0123456789abcdef" for char in sha256):
+        return None
+    return {"status": status, "sha256": sha256, "updated_at": updated_at}
+
+
 def gallery_row(
     item: Mapping[str, object],
     *,
@@ -100,6 +113,7 @@ def gallery_row(
         "available": local or webdav,
         "width": _positive_int_or_none(item.get("width")),
         "height": _positive_int_or_none(item.get("height")),
+        "genbox_push": _genbox_push_state(item.get("genbox_push")),
     }
 
 

--- a/services/genbox_push_service.py
+++ b/services/genbox_push_service.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from curl_cffi import requests
+from fastapi import HTTPException
+
+from services.config import config
+from services.image_storage_service import image_storage_service, normalize_image_relative_path
+
+
+_ALLOWED_STATUSES = {"imported", "already-imported", "duplicate-local"}
+
+
+def _error(status_code: int, code: str) -> HTTPException:
+    return HTTPException(status_code=status_code, detail={"error": code})
+
+
+def _json_object(response: Any) -> dict[str, Any]:
+    content = bytes(response.content or b"")
+    if len(content) > 1024 * 1024:
+        raise _error(502, "genbox_invalid_receipt")
+    def object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        value: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in value:
+                raise ValueError("duplicate receipt key")
+            value[key] = item
+        return value
+    try:
+        value = json.loads(content.decode("utf-8"), object_pairs_hook=object_pairs)
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise _error(502, "genbox_invalid_receipt") from exc
+    if not isinstance(value, dict):
+        raise _error(502, "genbox_invalid_receipt")
+    return value
+
+
+def _settings() -> dict[str, object]:
+    settings = config.get_genbox_push_settings()
+    required = ("base_url", "source_id", "push_key")
+    if not settings.get("enabled") or any(not str(settings.get(key) or "").strip() for key in required):
+        raise _error(409, "genbox_not_configured")
+    return settings
+
+
+def _validate_probe(value: Mapping[str, Any], source_id: str, size: int) -> None:
+    if (
+        value.get("ok") is not True
+        or value.get("contract_version") != "v1"
+        or value.get("source_id") != source_id
+        or not isinstance(value.get("max_image_bytes"), int)
+        or value["max_image_bytes"] < size
+    ):
+        raise _error(502, "genbox_probe_rejected")
+
+
+def _validate_receipt(value: Mapping[str, Any], source_id: str, sha256: str) -> str:
+    status = value.get("status")
+    if (
+        value.get("ok") is not True
+        or value.get("contract_version") != "v1"
+        or value.get("source_id") != source_id
+        or value.get("sha256") != sha256
+        or status not in _ALLOWED_STATUSES
+    ):
+        raise _error(502, "genbox_invalid_receipt")
+    return str(status)
+
+
+def push_gallery_image(relative_path: str) -> dict[str, object]:
+    settings = _settings()
+    rel = normalize_image_relative_path(relative_path)
+    payload = image_storage_service.get_bytes(rel)
+    sha256 = hashlib.sha256(payload).hexdigest()
+    headers = {
+        "X-GenBox-Source": str(settings["source_id"]),
+        "X-GenBox-Key": str(settings["push_key"]),
+    }
+    timeout = int(settings["timeout_secs"])
+    session = requests.Session(verify=True)
+    try:
+        try:
+            probe = session.get(
+                f"{str(settings['base_url']).rstrip('/')}/api/sync/push/status",
+                headers=headers,
+                timeout=timeout,
+                allow_redirects=False,
+            )
+            if not 200 <= int(probe.status_code) < 300:
+                raise _error(502, "genbox_unavailable")
+            _validate_probe(_json_object(probe), str(settings["source_id"]), len(payload))
+            response = session.post(
+                f"{str(settings['base_url']).rstrip('/')}/api/sync/push",
+                headers=headers,
+                files={"image": (Path(rel).name, payload, "application/octet-stream")},
+                data={"remote_path": rel, "source_sha256": sha256},
+                timeout=timeout,
+                allow_redirects=False,
+            )
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise _error(504, "genbox_request_failed") from exc
+        if not 200 <= int(response.status_code) < 300:
+            raise _error(502, "genbox_rejected")
+        status = _validate_receipt(_json_object(response), str(settings["source_id"]), sha256)
+    finally:
+        session.close()
+    updated_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    state = image_storage_service.record_genbox_push(rel, status=status, sha256=sha256, updated_at=updated_at)
+    return {"path": rel, **state, "source_retained": True}

--- a/services/image_storage_service.py
+++ b/services/image_storage_service.py
@@ -477,6 +477,24 @@ class ImageStorageService:
                 client.session.close()
         raise HTTPException(status_code=404, detail="image not found")
 
+    def record_genbox_push(self, rel: str, *, status: str, sha256: str, updated_at: str) -> dict[str, str]:
+        safe_rel = normalize_image_relative_path(rel)
+        if not _is_image_rel(safe_rel):
+            raise HTTPException(status_code=404, detail="image not found")
+        with self._item_guard(safe_rel), self._index_guard():
+            items = self._load_clean_index()
+            item = items.get(safe_rel)
+            if item is None:
+                raise HTTPException(status_code=404, detail="image not found")
+            item["genbox_push"] = {
+                "status": status,
+                "sha256": sha256,
+                "updated_at": updated_at,
+            }
+            items[safe_rel] = item
+            self._save_index(items)
+        return dict(item["genbox_push"])
+
     def exists(self, rel: str) -> bool:
         return bool(self.existing_paths([rel]))
 

--- a/services/settings_management_service.py
+++ b/services/settings_management_service.py
@@ -13,6 +13,7 @@ from contracts.settings import (
     AIReviewSettings,
     BackupIncludeSettings,
     BackupSettings,
+    GenBoxPushSettings,
     ImageStorageSettings,
     InfiniteCanvasSettings,
     PublicInfiniteCanvasSettings,
@@ -34,6 +35,7 @@ from contracts.settings_specification import (
 )
 from services.config import (
     DEFAULT_BACKUP_INCLUDE,
+    DEFAULT_GENBOX_PUSH,
     DEFAULT_IMAGE_STORAGE,
     DEFAULT_PROXY_RUNTIME,
     DEFAULT_PROXY_RUNTIME_USER_AGENT,
@@ -68,6 +70,7 @@ _MANAGED_TOP_LEVEL_FIELDS = (
     "sensitive_words",
     "ai_review",
     "image_storage",
+    "genbox_push",
     "backup",
     "third_party_apps",
 )
@@ -75,6 +78,7 @@ _MANAGED_TOP_LEVEL_FIELDS = (
 _SENSITIVE_PATHS = (
     ("ai_review", "api_key"),
     ("image_storage", "webdav_password"),
+    ("genbox_push", "push_key"),
     ("backup", "secret_access_key"),
     ("backup", "passphrase"),
     ("proxy_runtime", "clearance", "cf_cookies"),
@@ -262,6 +266,11 @@ _FIELD_SPECS: dict[str, dict[str, Any]] = {
     "image_storage.webdav_password": _field_metadata("", sensitive=True),
     "image_storage.webdav_root_path": _field_metadata(DEFAULT_IMAGE_STORAGE["webdav_root_path"]),
     "image_storage.public_base_url": _field_metadata(""),
+    "genbox_push.enabled": _field_metadata(False),
+    "genbox_push.base_url": _field_metadata(""),
+    "genbox_push.source_id": _field_metadata(""),
+    "genbox_push.push_key": _field_metadata("", sensitive=True),
+    "genbox_push.timeout_secs": _field_metadata(20, min=5, max=120, unit="seconds"),
     "backup.enabled": _field_metadata(False),
     "backup.provider": _field_metadata("cloudflare_r2", options=("cloudflare_r2",), read_only=True),
     "backup.account_id": _field_metadata(""),
@@ -312,6 +321,7 @@ class SettingsManagementService:
     def update(self, patch: SettingsPatch) -> SettingsMutationResult:
         values = patch.model_dump(mode="python", exclude_unset=True)
         expected_revision = _text(values.pop("revision"))
+        clear_genbox_push = bool(_path_value(values, ("genbox_push", "clear_push_key")))
         self._drop_blank_sensitive_values(values)
 
         with self._mutation_lock, self._config_lock():
@@ -324,6 +334,14 @@ class SettingsManagementService:
                 raise ValueError("base_url is read-only while CHATGPT2API_BASE_URL is configured")
 
             updates = self._storage_updates(values, effective, stored)
+            if clear_genbox_push:
+                genbox_updates = updates.get("genbox_push")
+                if isinstance(genbox_updates, dict):
+                    genbox_updates.pop("clear_push_key", None)
+                    incoming_genbox = values.get("genbox_push")
+                    incoming_push_key = incoming_genbox.get("push_key") if isinstance(incoming_genbox, Mapping) else None
+                    if not _text(incoming_push_key):
+                        genbox_updates.pop("push_key", None)
             requested_paths = _leaf_paths(values)
             current_values = self._project_settings(effective, stored).model_dump(mode="python")
             candidate_paths = [
@@ -332,6 +350,8 @@ class SettingsManagementService:
                 if self._comparison_value(current_values, stored, path) != self._comparison_value(updates, updates, path)
             ]
             changed_roots = {path[0] for path in candidate_paths}
+            if clear_genbox_push:
+                changed_roots.add("genbox_push")
             changed_updates = {
                 key: value for key, value in updates.items()
                 if key in changed_roots
@@ -349,6 +369,9 @@ class SettingsManagementService:
                 != self._comparison_value(next_values, next_stored, path)
             ]
             changed_fields = sorted(".".join(path) for path in changed_paths)
+            if clear_genbox_push:
+                changed_fields.append("genbox_push.push_key")
+                changed_fields = sorted(set(changed_fields))
             restart_required = any(
                 view.fields.get(path, SettingsFieldMetadata(source="configured")).restart_required
                 for path in changed_fields
@@ -412,6 +435,8 @@ class SettingsManagementService:
         stored_ai_review = _dict(stored.get("ai_review"))
         image_storage = _dict(effective.get("image_storage"))
         stored_image_storage = _dict(stored.get("image_storage"))
+        genbox_push = _dict(effective.get("genbox_push"))
+        stored_genbox_push = _dict(stored.get("genbox_push"))
         backup = _dict(effective.get("backup"))
         stored_backup = _dict(stored.get("backup"))
         backup_include = _dict(backup.get("include"))
@@ -527,6 +552,14 @@ class SettingsManagementService:
                     or str(DEFAULT_IMAGE_STORAGE["webdav_root_path"])
                 ),
                 public_base_url=_url(image_storage.get("public_base_url")),
+            ),
+            genbox_push=GenBoxPushSettings(
+                enabled=_bool(genbox_push.get("enabled"), False),
+                base_url=_url(genbox_push.get("base_url")),
+                source_id=_text(genbox_push.get("source_id")),
+                push_key="",
+                has_push_key=bool(_text(stored_genbox_push.get("push_key"))),
+                timeout_secs=max(5, min(120, int(genbox_push.get("timeout_secs") or DEFAULT_GENBOX_PUSH["timeout_secs"]))),
             ),
             backup=BackupSettings(
                 enabled=_bool(backup.get("enabled"), False),

--- a/web-vue/src/api/gallery.ts
+++ b/web-vue/src/api/gallery.ts
@@ -4,6 +4,19 @@ export type GalleryMediaType = 'all' | 'image'
 export type GalleryFileMediaType = Exclude<GalleryMediaType, 'all'>
 export type GalleryStorage = 'local' | 'webdav' | 'both'
 
+export type GalleryGenBoxPushStatus = 'imported' | 'already-imported' | 'duplicate-local'
+
+export interface GalleryGenBoxPushState {
+  status: GalleryGenBoxPushStatus
+  sha256: string
+  updated_at: string
+}
+
+export interface GalleryGenBoxPushResult extends GalleryGenBoxPushState {
+  path: string
+  source_retained: boolean
+}
+
 export interface GalleryRow {
   id: string
   path: string
@@ -24,6 +37,7 @@ export interface GalleryRow {
   available: boolean
   width: number | null
   height: number | null
+  genbox_push: GalleryGenBoxPushState | null
 }
 
 export type GalleryFile = Omit<GalleryRow, 'storage'> & {
@@ -158,4 +172,9 @@ export const galleryApi = {
 
   cleanupExpired: () =>
     apiClient.post<never, GalleryCleanupResult>('/api/images/retention-cleanup'),
+
+  pushToGenBox: (path: string) =>
+    apiClient.post<{ path: string }, GalleryGenBoxPushResult>('/api/images/genbox-push', {
+      path,
+    }),
 }

--- a/web-vue/src/components/ai/GalleryImageCard.vue
+++ b/web-vue/src/components/ai/GalleryImageCard.vue
@@ -39,6 +39,18 @@
         <button class="overlay-btn" title="下载" @click.stop="handleDownload">
           <Icon icon="lucide:download" />
         </button>
+        <button
+          class="overlay-btn"
+          :class="{ 'is-busy': genboxBusy }"
+          :disabled="genboxBusy"
+          :title="genboxBusy ? '正在推送 GenBox' : '推送到 GenBox'"
+          @click.stop="handleGenBoxPush"
+        >
+          <Icon
+            :icon="genboxBusy ? 'lucide:loader-circle' : 'lucide:cloud-upload'"
+            :class="{ 'animate-spin': genboxBusy }"
+          />
+        </button>
         <button class="overlay-btn danger" title="删除" @click.stop="handleDelete">
           <Icon icon="lucide:trash-2" />
         </button>
@@ -88,6 +100,7 @@ const props = defineProps<{
   sizeLabel: string
   dimensions: string
   timeRemaining: string
+  genboxBusy: boolean
 }>()
 
 const emit = defineEmits<{
@@ -97,6 +110,7 @@ const emit = defineEmits<{
   (e: 'copy', file: GalleryFile): void
   (e: 'edit-tags', file: GalleryFile): void
   (e: 'download', file: GalleryFile): void
+  (e: 'genbox-push', file: GalleryFile): void
   (e: 'delete', file: GalleryFile): void
   (e: 'tag-click', tag: string): void
 }>()
@@ -123,6 +137,10 @@ function handleEditTags() {
 
 function handleDownload() {
   emit('download', props.file)
+}
+
+function handleGenBoxPush() {
+  emit('genbox-push', props.file)
 }
 
 function handleDelete() {
@@ -278,6 +296,17 @@ function handleTagClick(tag: string) {
 .overlay-btn.danger:hover {
   background: hsl(0 84.2% 60.2%);
   color: white;
+}
+
+.overlay-btn:disabled {
+  cursor: default;
+  opacity: 0.72;
+}
+
+.overlay-btn:disabled:hover {
+  transform: none;
+  background: var(--gallery-float-bg);
+  color: var(--gallery-float-fg);
 }
 
 .overlay-btn svg {

--- a/web-vue/src/components/studio/StudioLightbox.vue
+++ b/web-vue/src/components/studio/StudioLightbox.vue
@@ -51,6 +51,7 @@ const lightboxFile = computed<GalleryFile | null>(() => {
     available: true,
     width: null,
     height: null,
+    genbox_push: null,
   }
 })
 

--- a/web-vue/src/lib/localLucideIcons.generated.ts
+++ b/web-vue/src/lib/localLucideIcons.generated.ts
@@ -21,6 +21,7 @@ export const localLucideIconNames = [
   "clipboard-paste",
   "clock",
   "clock-3",
+  "cloud-upload",
   "coins",
   "columns-2",
   "copy",
@@ -130,6 +131,9 @@ export const localLucideIcons = {
     },
     "clock-3": {
       "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><circle cx=\"12\" cy=\"12\" r=\"10\"/><path d=\"M12 6v6h4\"/></g>"
+    },
+    "cloud-upload": {
+      "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><path d=\"M12 13v8m-8-6.101A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242\"/><path d=\"m8 17l4-4l4 4\"/></g>"
     },
     "coins": {
       "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><path d=\"M13.744 17.736a6 6 0 1 1-7.48-7.48M15 6h1v4\"/><path d=\"m6.134 14.768l.866-.5l2 3.464\"/><circle cx=\"16\" cy=\"8\" r=\"6\"/></g>"

--- a/web-vue/src/types/api.ts
+++ b/web-vue/src/types/api.ts
@@ -53,6 +53,15 @@ export interface ClearanceTestResult {
   runtime?: ProxyRuntimeStatus
 }
 
+export interface SettingsGenBoxPush {
+  enabled: boolean
+  base_url: string
+  source_id: string
+  push_key: string
+  has_push_key: boolean
+  timeout_secs: number
+}
+
 export interface Settings {
   proxy_runtime: SettingsProxyRuntimeSettings
   base_url: string
@@ -93,6 +102,7 @@ export interface Settings {
     webdav_root_path: string
     public_base_url: string
   }
+  genbox_push: SettingsGenBoxPush
   backup: {
     enabled: boolean
     provider: string

--- a/web-vue/src/views/Gallery.vue
+++ b/web-vue/src/views/Gallery.vue
@@ -128,12 +128,14 @@
             :size-label="formatSize(file.size_bytes)"
             :dimensions="formatDimensions(file)"
             :time-remaining="galleryCardTimeRemaining(file)"
+            :genbox-busy="genboxPushBusyPath === file.path"
             @preview="openPreview"
             @select="handleCardSelect"
             @image-error="handleCardImageError"
             @copy="copyFileLink"
             @edit-tags="openTagEditor"
             @download="downloadFile"
+            @genbox-push="handleGenBoxPush"
             @delete="handleDelete"
             @tag-click="setTagFilter"
           />
@@ -437,6 +439,8 @@ const {
   handleDelete,
   handleDeleteSelected,
   handleBatchDownload,
+  genboxPushBusyPath,
+  handleGenBoxPush,
 } = galleryOperations
 
 function getFileUrl(url: string) {
@@ -461,6 +465,7 @@ function galleryCardSignature(file: GalleryFile) {
     sizeLabel: formatSize(file.size_bytes),
     dimensions: formatDimensions(file),
     timeRemaining: galleryCardTimeRemaining(file),
+    genboxBusy: genboxPushBusyPath.value === file.path,
   })
 }
 

--- a/web-vue/src/views/gallery/galleryOperationsRuntime.ts
+++ b/web-vue/src/views/gallery/galleryOperationsRuntime.ts
@@ -42,6 +42,7 @@ export function useGalleryOperationsRuntime(options: GalleryOperationsRuntimeOpt
   const storageActionError = ref('')
   const targetFreeMb = ref('500')
   const batchBusy = ref(false)
+  const genboxPushBusyPath = ref<string | null>(null)
   const progressRuntime = useOperationProgressRuntime()
   const operationProgress = progressRuntime.state
 
@@ -257,6 +258,31 @@ export function useGalleryOperationsRuntime(options: GalleryOperationsRuntimeOpt
     }
   }
 
+  function genboxErrorMessage(error: any): string {
+    const code = error?.data?.error
+    if (code === 'genbox_not_configured') return 'GenBox 尚未配置'
+    if (code === 'genbox_request_failed') return 'GenBox 请求失败或超时'
+    if (code) return 'GenBox 未接受该图片'
+    return error?.message || '推送到 GenBox 失败'
+  }
+
+  async function handleGenBoxPush(file: GalleryFile) {
+    if (genboxPushBusyPath.value) return
+    genboxPushBusyPath.value = file.path
+    try {
+      const result = await galleryApi.pushToGenBox(file.path)
+      options.toast.success(
+        result.status === 'imported' ? '已推送到 GenBox' : '图片已存在于 GenBox',
+        'Push 成功',
+      )
+      await options.loadGallery()
+    } catch (error: any) {
+      options.toast.error(genboxErrorMessage(error), 'Push 失败')
+    } finally {
+      genboxPushBusyPath.value = null
+    }
+  }
+
   function deactivate() {
     storageStatsQuery.invalidate()
     isStorageBusy.value = false
@@ -264,6 +290,7 @@ export function useGalleryOperationsRuntime(options: GalleryOperationsRuntimeOpt
 
   return {
     batchBusy,
+    genboxPushBusyPath,
     isStorageModalOpen,
     isStorageBusy,
     storageActionMessage,
@@ -280,6 +307,7 @@ export function useGalleryOperationsRuntime(options: GalleryOperationsRuntimeOpt
     handleDelete,
     handleDeleteSelected,
     handleBatchDownload,
+    handleGenBoxPush,
     deactivate,
   }
 }

--- a/web-vue/src/views/gallery/galleryView.ts
+++ b/web-vue/src/views/gallery/galleryView.ts
@@ -29,6 +29,7 @@ export type GalleryFileCardSignatureInput = {
   sizeLabel: string
   dimensions: string
   timeRemaining: string
+  genboxBusy: boolean
 }
 
 function signatureValue(value: unknown): string {
@@ -85,6 +86,8 @@ export function galleryFileCardSignature(file: GalleryFile, input: GalleryFileCa
     input.sizeLabel,
     input.dimensions,
     input.timeRemaining,
+    input.genboxBusy ? 1 : 0,
+    file.genbox_push ? `${file.genbox_push.status}:${file.genbox_push.updated_at}` : '',
     file.tags.map((tag) => boundedSignatureText(tag, 64)).join(','),
   ].map(signatureValue).join('|')
 }

--- a/web-vue/src/views/logs/logsView.ts
+++ b/web-vue/src/views/logs/logsView.ts
@@ -281,6 +281,7 @@ export function buildLogPreviewGalleryFile(image: LogPreviewImage | null | undef
     available: true,
     width: null,
     height: null,
+    genbox_push: null,
   }
 }
 


### PR DESCRIPTION
## 背景

在 Gallery 图片库中，对单张已有图片支持手动执行 "Push to GenBox"。

此前提交的 PR 因上游 main 被 reset 而自动关闭；本 PR 已基于最新 main（ca744d520aa862ee94c28933807726bdd063a0df）重新整理后再次提交。

## 功能

- Gallery 图片卡片新增 "Push to GenBox" 操作，只作用于单张图片；
- GenBox 默认未配置：不发送任何网络请求，不改变原有行为；
- 未配置时点击会提示 `genbox_not_configured`，前端不发请求；
- Push 成功只保存非敏感结果状态（`status`、`sha256`、`updated_at`）；
- Push 失败、超时、认证失败、receipt 不合法时，原图片仍然保留且可访问；
- 即使 receipt 返回 `safe_to_delete_source`，也一律忽略；
- 不执行任何删除、cleanup、磁盘回收或源文件修改。

## 设置字段

新增 `genbox_push` 配置：

- `enabled`：是否启用（默认 `false`）
- `base_url`：GenBox 服务地址
- `source_id`：GenBox 源标识
- `push_key`：Push Key，只写入；对外读取时仅返回 `has_push_key`，不回传明文
- `timeout_secs`：请求超时秒数（默认 `20`，范围 `5-120`）

## 给作者的建议：设置页加小白说明和快速跳转

建议在设置页 `genbox_push` 各输入框旁边，用一行大白话说明用途，方便不熟悉 GenBox 的用户填写：

- `enabled`：是否启用 GenBox Push。不勾选就完全不联网，原功能不受影响。
- `base_url`：GenBox 服务的访问地址，形如 `http://host:port`，请填写你实际部署 GenBox 的地址。
- `source_id`：GenBox 里的源标识（Source ID），用于识别是哪台机器/哪个项目推送上来的图片。
- `push_key`：GenBox 的 Push Key，相当于推送口令。只在这里填写，不会显示明文，也不会写进日志。
- `timeout_secs`：单次推送最多等待多少秒。默认 20 秒，可在 5-120 秒之间调整。

如果 GenBox 与 chatgpt2api 运行在同一台宿主机上，建议在设置项旁提供一个“打开 GenBox”快速跳转按钮：点击后直接在新标签页打开 `base_url` 对应页面，用户就能快速查看源标识和 Push Key。

## 后端 API

`POST /api/images/genbox-push`

- 请求：`{ "path": "images/xxx.png" }`
- 成功：`200`，返回 `{ "path", "status", "sha256", "updated_at", "source_retained": true }`
- 未配置：`409`，`{ "error": "genbox_not_configured" }`
- 失败/超时/认证失败/receipt 不合法：返回 `502/504` 对应错误，原图片保留

Push 流程为：先调用 `/api/sync/push/status` 探测并校验容量，再调用 `/api/sync/push` 上传；receipt 会校验 `contract_version`、`source_id`、`sha256` 与状态合法性。

## 安全与不变量

- Push Key 不写入日志、不回传前端、不保存到图片元数据；
- 状态文件只保存非敏感字段；
- 未配置时零网络请求、零状态读取；
- 不触碰删除/cleanup/源文件写入路径。

## 验证

- 后端聚焦测试：`16 passed, 14 subtests passed`
- 前端 runtime 测试通过
- `npm run build` 通过

说明：测试文件位于 `.gitignore` 内的 `tests/` 与 `web-vue/tests/`，因此未包含在本 PR 中；本地已全部验证。
