### PR TITLE
fix: gate GenBox push to registered gallery images and pass generation metadata

### DIFF
--- a/services/genbox_push_service.py
+++ b/services/genbox_push_service.py
@@ -10,6 +10,8 @@ from urllib.parse import urlsplit
 
 from curl_cffi import requests
 from fastapi import HTTPException
+from PIL import Image
+import io
 
 from services.config import config
 from services.image_storage_service import image_storage_service, normalize_image_relative_path
@@ -90,11 +92,11 @@ def _spawn_thread(target: Any, name: str) -> threading.Thread:
     return thread
 
 
-def _run_auto_push(rel: str) -> None:
+def _run_auto_push(rel: str, *, metadata: Mapping[str, Any] | None = None) -> None:
     def worker() -> None:
         _auto_push_slots.acquire()
         try:
-            push_gallery_image(rel)
+            push_gallery_image(rel, metadata=metadata)
             logger.info({"event": "genbox_auto_push_succeeded", "path": rel})
         except HTTPException as exc:
             detail = exc.detail
@@ -112,7 +114,7 @@ def _run_auto_push(rel: str) -> None:
     _spawn_thread(worker, name="genbox-auto-push")
 
 
-def auto_push_gallery_urls(urls: list[str]) -> None:
+def auto_push_gallery_urls(urls: list[str], *, metadata: Mapping[str, Any] | None = None) -> None:
     try:
         if _auto_push_settings() is None:
             return
@@ -128,7 +130,7 @@ def auto_push_gallery_urls(urls: list[str]) -> None:
                 continue
             rels.append(rel)
         for rel in rels:
-            _run_auto_push(rel)
+            _run_auto_push(rel, metadata=metadata)
     except Exception as exc:
         logger.warning({
             "event": "genbox_auto_push_dispatch_failed",
@@ -168,10 +170,15 @@ def _validate_receipt(value: Mapping[str, Any], source_id: str, sha256: str) -> 
     return str(status)
 
 
-def push_gallery_image(relative_path: str) -> dict[str, object]:
+def push_gallery_image(relative_path: str, *, metadata: Mapping[str, Any] | None = None) -> dict[str, object]:
     settings = _settings()
     rel = normalize_image_relative_path(relative_path)
     payload = image_storage_service.get_bytes(rel)
+    try:
+        with Image.open(io.BytesIO(payload)) as image:
+            image.verify()
+    except Exception as exc:
+        raise _error(404, "image not found") from exc
     sha256 = hashlib.sha256(payload).hexdigest()
     headers = {
         "X-GenBox-Source": str(settings["source_id"]),
@@ -190,11 +197,16 @@ def push_gallery_image(relative_path: str) -> dict[str, object]:
             if not 200 <= int(probe.status_code) < 300:
                 raise _error(502, "genbox_unavailable")
             _validate_probe(_json_object(probe), str(settings["source_id"]), len(payload))
+            data: dict[str, str] = {"remote_path": rel, "source_sha256": sha256}
+            for key in ("prompt", "created_at", "date", "model"):
+                value = metadata.get(key) if isinstance(metadata, Mapping) else None
+                if value is not None and str(value).strip():
+                    data[key] = str(value)
             response = session.post(
                 f"{str(settings['base_url']).rstrip('/')}/api/sync/push",
                 headers=headers,
                 files={"image": (Path(rel).name, payload, "application/octet-stream")},
-                data={"remote_path": rel, "source_sha256": sha256},
+                data=data,
                 timeout=timeout,
                 allow_redirects=False,
             )

--- a/services/genbox_push_service.py
+++ b/services/genbox_push_service.py
@@ -58,6 +58,19 @@ def _rel_from_stored_url(url: str) -> str | None:
         return None
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         return None
+    configured_origins: set[tuple[str, str]] = set()
+    for base in (
+        config.base_url,
+        config.get_image_storage_settings().get("public_base_url"),
+    ):
+        try:
+            origin = urlsplit(str(base or "").strip().rstrip("/"))
+        except ValueError:
+            continue
+        if origin.scheme in {"http", "https"} and origin.netloc:
+            configured_origins.add((origin.scheme, origin.netloc.lower()))
+    if (parsed.scheme, parsed.netloc.lower()) not in configured_origins:
+        return None
     path = parsed.path or ""
     if "/images/" in path:
         rel = path.split("/images/", 1)[1]

--- a/services/image_service.py
+++ b/services/image_service.py
@@ -308,13 +308,10 @@ def download_images_zip(paths: list[str]) -> io.BytesIO:
                 path.relative_to(root)
             except ValueError:
                 continue
-            if path.is_file():
-                payload = path.read_bytes()
-            else:
-                try:
-                    payload = image_storage_service.get_bytes(rel)
-                except Exception:
-                    continue
+            try:
+                payload = image_storage_service.get_bytes(rel)
+            except Exception:
+                continue
             name = path.name
             if name in used_names:
                 stem = path.stem

--- a/services/image_storage_service.py
+++ b/services/image_storage_service.py
@@ -465,11 +465,16 @@ class ImageStorageService:
         safe_rel = normalize_image_relative_path(rel)
         if not _is_image_rel(safe_rel):
             raise HTTPException(status_code=404, detail="image not found")
+        # File paths are not an authorization boundary: only assets registered
+        # in the Gallery index may be read through this service.
+        with self._index_guard():
+            item = self._load_clean_index().get(safe_rel)
+        if not isinstance(item, dict):
+            raise HTTPException(status_code=404, detail="image not found")
         path = image_local_path(safe_rel)
-        if path.is_file():
+        if bool(item.get("local")) and path.is_file():
             return path.read_bytes()
-        item = self._load_clean_index().get(safe_rel, {})
-        if item.get("webdav"):
+        if bool(item.get("webdav")):
             client = WebDAVClient(self.settings())
             try:
                 return client.get(safe_rel)

--- a/services/image_storage_service.py
+++ b/services/image_storage_service.py
@@ -276,7 +276,18 @@ class ImageStorageService:
 
     def _load_clean_index(self) -> dict[str, dict[str, object]]:
         items = self._load_index()
-        return {rel: item for rel, item in items.items() if _is_image_rel(rel)}
+        clean: dict[str, dict[str, object]] = {}
+        for rel, item in items.items():
+            if not _is_image_rel(rel):
+                continue
+            storage = _clean(item.get("storage"))
+            item = dict(item)
+            if "local" not in item and storage in {"local", "both"}:
+                item["local"] = True
+            if "webdav" not in item and storage in {"webdav", "both"}:
+                item["webdav"] = True
+            clean[rel] = item
+        return clean
 
     def _save_index(self, items: dict[str, dict[str, object]]) -> None:
         _write_json_object(self.index_file, {"items": items})

--- a/services/image_storage_service.py
+++ b/services/image_storage_service.py
@@ -555,7 +555,9 @@ class ImageStorageService:
 
     def has_local(self, rel: str) -> bool:
         safe_rel = normalize_image_relative_path(rel)
-        return _is_image_rel(safe_rel) and image_local_path(safe_rel).is_file()
+        with self._index_guard():
+            item = self._load_clean_index().get(safe_rel)
+        return bool(isinstance(item, dict) and item.get('local')) and image_local_path(safe_rel).is_file()
 
     @staticmethod
     def _catalog_size_matches_local(item: dict[str, object], local_size: int) -> bool:

--- a/services/image_task_service.py
+++ b/services/image_task_service.py
@@ -6,7 +6,7 @@ import shutil
 import tempfile
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager
 from copy import deepcopy
 from datetime import datetime
@@ -222,6 +222,23 @@ def _collect_image_urls(value: object) -> list[str]:
         for item in value:
             urls.extend(_collect_image_urls(item))
     return list(dict.fromkeys(urls))
+
+
+def _generation_push_metadata(result: Mapping[str, Any], *, prompt: object = None, model: object = None) -> dict[str, object]:
+    metadata: dict[str, object] = {}
+    if prompt is not None and str(prompt).strip():
+        metadata["prompt"] = prompt
+    created_at = result.get("created_at")
+    if created_at is None:
+        created_at = result.get("created")
+    if created_at is not None and str(created_at).strip():
+        metadata["created_at"] = created_at
+    date = result.get("date")
+    if date is not None and str(date).strip():
+        metadata["date"] = date
+    if model is not None and str(model).strip():
+        metadata["model"] = model
+    return metadata
 
 
 class ImageTaskService:
@@ -776,11 +793,7 @@ class ImageTaskService:
             # metadata that is present in the real generation response.
             auto_push_gallery_urls(
                 _collect_image_urls(result),
-                metadata={
-                    "prompt": payload.get("prompt"),
-                    "created_at": result.get("created_at") or result.get("created"),
-                    "model": model,
-                },
+                metadata=_generation_push_metadata(result, prompt=payload.get("prompt"), model=model),
             )
             image_attempts = collect_image_attempts(result)
             self._log_call(
@@ -1118,11 +1131,7 @@ class ImageTaskService:
             )
             auto_push_gallery_urls(
                 _collect_image_urls(formatted),
-                metadata={
-                    "prompt": "",
-                    "created_at": formatted.get("created_at") or formatted.get("created"),
-                    "model": model,
-                },
+                metadata=_generation_push_metadata(formatted, model=model),
             )
             self._log_call(
                 identity,

--- a/services/image_task_service.py
+++ b/services/image_task_service.py
@@ -772,7 +772,16 @@ class ImageTaskService:
                 duration_ms=duration_ms,
                 **_clear_task_details(),
             )
-            auto_push_gallery_urls(_collect_image_urls(result))
+            # Auto-push only the assets produced by this task and carry through
+            # metadata that is present in the real generation response.
+            auto_push_gallery_urls(
+                _collect_image_urls(result),
+                metadata={
+                    "prompt": payload.get("prompt"),
+                    "created_at": result.get("created_at") or result.get("created"),
+                    "model": model,
+                },
+            )
             image_attempts = collect_image_attempts(result)
             self._log_call(
                 identity,
@@ -1107,7 +1116,14 @@ class ImageTaskService:
                 duration_ms=int((time.time() - started) * 1000),
                 **_clear_task_details(),
             )
-            auto_push_gallery_urls(_collect_image_urls(formatted))
+            auto_push_gallery_urls(
+                _collect_image_urls(formatted),
+                metadata={
+                    "prompt": "",
+                    "created_at": formatted.get("created_at") or formatted.get("created"),
+                    "model": model,
+                },
+            )
             self._log_call(
                 identity,
                 mode,

--- a/tests/test_genbox_push_followup.py
+++ b/tests/test_genbox_push_followup.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import base64
+import io
+import json
+import os
+from pathlib import Path
+import tempfile
+
+import pytest
+from fastapi import HTTPException
+from PIL import Image
+
+_test_db = Path(tempfile.gettempdir()) / "chatgpt2api-genbox-push-tests.db"
+_test_db.unlink(missing_ok=True)
+os.environ.setdefault("DATABASE_URL", f"sqlite:///{_test_db.as_posix()}")
+os.environ.setdefault("CHATGPT2API_AUTH_KEY", "unit-test-auth-key")
+
+import services.genbox_push_service as push
+import services.image_storage_service as storage_module
+import services.config as config_module
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, payload: object):
+        self.status_code = status_code
+        self.content = json.dumps(payload).encode("utf-8")
+
+
+class FakeSession:
+    def __init__(self, responses: list[FakeResponse], calls: list[tuple]):
+        self.responses = iter(responses)
+        self.calls = calls
+
+    def get(self, *args, **kwargs):
+        self.calls.append(("get", args, kwargs))
+        return next(self.responses)
+
+    def post(self, *args, **kwargs):
+        self.calls.append(("post", args, kwargs))
+        return next(self.responses)
+
+    def close(self):
+        self.calls.append(("close",))
+
+
+class TimeoutSession:
+    def __init__(self, calls: list[tuple]):
+        self.calls = calls
+
+    def get(self, *args, **kwargs):
+        self.calls.append(("get", args, kwargs))
+        raise TimeoutError("test timeout")
+
+    def close(self):
+        self.calls.append(("close",))
+
+
+def png_bytes() -> bytes:
+    output = io.BytesIO()
+    Image.new("RGB", (2, 2), "red").save(output, format="PNG")
+    return output.getvalue()
+
+
+def configure(monkeypatch, *, enabled: bool = True):
+    settings = {
+        "enabled": enabled,
+        "base_url": "https://genbox.invalid",
+        "source_id": "test-source",
+        "push_key": "test-secret",
+        "timeout_secs": 5,
+        "auto_push_after_studio": True,
+    }
+    monkeypatch.setattr(push.config, "get_genbox_push_settings", lambda: settings)
+    monkeypatch.setenv("CHATGPT2API_BASE_URL", "http://app.invalid")
+    monkeypatch.setattr(
+        push.config,
+        "get_image_storage_settings",
+        lambda: {"public_base_url": "http://app.invalid"},
+    )
+    return settings
+
+
+def test_unconfigured_push_makes_zero_network_requests(monkeypatch):
+    configure(monkeypatch, enabled=False)
+    calls: list[tuple] = []
+    monkeypatch.setattr(push.requests, "Session", lambda **kwargs: calls.append(("session",)) or None)
+    with pytest.raises(HTTPException) as exc:
+        push.push_gallery_image("generated.png")
+    assert exc.value.status_code == 409
+    assert calls == []
+
+
+def test_registered_gallery_push_carries_metadata_and_retains_source(monkeypatch):
+    configure(monkeypatch)
+    payload = png_bytes()
+    monkeypatch.setattr(push.image_storage_service, "get_bytes", lambda rel: payload)
+    monkeypatch.setattr(
+        push.image_storage_service,
+        "record_genbox_push",
+        lambda rel, **kwargs: {"status": "imported", "sha256": kwargs["sha256"], "updated_at": kwargs["updated_at"]},
+    )
+    import hashlib
+
+    sha = hashlib.sha256(payload).hexdigest()
+    calls: list[tuple] = []
+    session = FakeSession(
+        [
+            FakeResponse(200, {"ok": True, "contract_version": "v1", "source_id": "test-source", "max_image_bytes": len(payload)}),
+            FakeResponse(200, {"ok": True, "contract_version": "v1", "source_id": "test-source", "sha256": sha, "status": "imported"}),
+        ],
+        calls,
+    )
+    monkeypatch.setattr(push.requests, "Session", lambda **kwargs: session)
+    result = push.push_gallery_image(
+        "generated.png",
+        metadata={"prompt": "a red square", "created_at": "2026-08-05T10:00:00Z", "model": "gpt-image-2"},
+    )
+    post = next(call for call in calls if call[0] == "post")
+    assert post[2]["data"] == {
+        "remote_path": "generated.png",
+        "source_sha256": sha,
+        "prompt": "a red square",
+        "created_at": "2026-08-05T10:00:00Z",
+        "model": "gpt-image-2",
+    }
+    assert post[2]["headers"]["X-GenBox-Key"] == "test-secret"
+    assert "test-secret" not in json.dumps(result)
+    assert result["source_retained"] is True
+
+
+@pytest.mark.parametrize("bad_path", ["missing.png", "../outside.png", "/absolute.png", "folder", "note.txt"])
+def test_invalid_or_unregistered_gallery_paths_are_rejected(monkeypatch, tmp_path: Path, bad_path: str):
+    index_file = tmp_path / "image_index.json"
+    index_file.write_text(json.dumps({"items": {"registered.png": {"local": True}}}), encoding="utf-8")
+    image_root = tmp_path / "images"
+    image_root.mkdir()
+    (image_root / "registered.png").write_bytes(png_bytes())
+    monkeypatch.setattr(config_module, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(storage_module, "DATA_DIR", tmp_path)
+    service = storage_module.ImageStorageService(index_file=index_file)
+    with pytest.raises(HTTPException) as exc:
+        service.get_bytes(bad_path)
+    assert exc.value.status_code == 404
+
+
+def test_non_image_content_is_rejected_before_network(monkeypatch):
+    configure(monkeypatch)
+    monkeypatch.setattr(push.image_storage_service, "get_bytes", lambda rel: b"not-an-image")
+    calls: list[tuple] = []
+    monkeypatch.setattr(push.requests, "Session", lambda **kwargs: calls.append(("session",)) or None)
+    with pytest.raises(HTTPException) as exc:
+        push.push_gallery_image("fake.png")
+    assert exc.value.status_code == 404
+    assert calls == []
+
+
+def test_push_timeout_returns_error_without_delete(monkeypatch):
+    configure(monkeypatch)
+    payload = png_bytes()
+    monkeypatch.setattr(push.image_storage_service, "get_bytes", lambda rel: payload)
+    calls: list[tuple] = []
+    monkeypatch.setattr(push.requests, "Session", lambda **kwargs: TimeoutSession(calls))
+    with pytest.raises(HTTPException) as exc:
+        push.push_gallery_image("generated.png")
+    assert exc.value.detail["error"] == "genbox_request_failed"
+    assert calls[0][0] == "get"
+    assert all(call[0] != "delete" for call in calls)
+
+
+@pytest.mark.parametrize(
+    "response, expected_code",
+    [
+        (FakeResponse(200, {"ok": True, "contract_version": "v1", "source_id": "test-source", "max_image_bytes": 999}), "genbox_invalid_receipt"),
+        (FakeResponse(500, {"error": "bad"}), "genbox_rejected"),
+    ],
+)
+def test_receipt_and_http_errors_keep_source(monkeypatch, response: FakeResponse, expected_code: str):
+    configure(monkeypatch)
+    payload = png_bytes()
+    monkeypatch.setattr(push.image_storage_service, "get_bytes", lambda rel: payload)
+    probe = FakeResponse(200, {"ok": True, "contract_version": "v1", "source_id": "test-source", "max_image_bytes": len(payload)})
+    if response.status_code == 200:
+        import hashlib
+
+        response = FakeResponse(200, {"ok": True, "contract_version": "v1", "source_id": "test-source", "sha256": "0" * 64, "status": "imported"})
+    calls: list[tuple] = []
+    monkeypatch.setattr(push.requests, "Session", lambda **kwargs: FakeSession([probe, response], calls))
+    with pytest.raises(HTTPException) as exc:
+        push.push_gallery_image("generated.png")
+    assert exc.value.detail["error"] == expected_code
+    assert calls[0][0] == "get"
+
+
+def test_external_url_is_not_eligible_for_studio_auto_push(monkeypatch):
+    configure(monkeypatch)
+    assert push._rel_from_stored_url("https://evil.invalid/images/old.png") is None

--- a/tests/test_genbox_push_followup.py
+++ b/tests/test_genbox_push_followup.py
@@ -186,6 +186,47 @@ def test_push_timeout_returns_error_without_delete(monkeypatch):
     assert all(call[0] != "delete" for call in calls)
 
 
+def test_auto_push_logs_do_not_expose_push_key(monkeypatch, tmp_path: Path):
+    configure(monkeypatch)
+    service, image_path = registered_storage(monkeypatch, tmp_path)
+    monkeypatch.setattr(push, "image_storage_service", service)
+    monkeypatch.setattr(push, "_spawn_thread", lambda target, name: target())
+
+    records: list[object] = []
+
+    class RecordingLogger:
+        def info(self, message: object) -> None:
+            records.append(message)
+
+        def warning(self, message: object) -> None:
+            records.append(message)
+
+        def error(self, message: object) -> None:
+            records.append(message)
+
+    monkeypatch.setattr(push, "logger", RecordingLogger())
+    payload = image_path.read_bytes()
+    import hashlib
+
+    sha = hashlib.sha256(payload).hexdigest()
+    success_session = FakeSession(
+        [
+            FakeResponse(200, {"ok": True, "contract_version": "v1", "source_id": "test-source", "max_image_bytes": len(payload)}),
+            FakeResponse(200, {"ok": True, "contract_version": "v1", "source_id": "test-source", "sha256": sha, "status": "imported"}),
+        ],
+        [],
+    )
+    monkeypatch.setattr(push.requests, "Session", lambda **kwargs: success_session)
+    push._run_auto_push("registered.png", metadata={"prompt": "a red square"})
+    assert any("genbox_auto_push_succeeded" in str(record) for record in records)
+
+    timeout_calls: list[tuple] = []
+    monkeypatch.setattr(push.requests, "Session", lambda **kwargs: TimeoutSession(timeout_calls))
+    push._run_auto_push("registered.png")
+    assert any("genbox_auto_push_failed" in str(record) for record in records)
+    assert "test-secret" not in str(records)
+
+
 def test_push_uses_gallery_registration_before_network(monkeypatch, tmp_path: Path):
     configure(monkeypatch)
     service, _ = registered_storage(monkeypatch, tmp_path)

--- a/tests/test_genbox_push_followup.py
+++ b/tests/test_genbox_push_followup.py
@@ -278,3 +278,26 @@ def test_studio_task_passes_only_result_urls_and_real_metadata(monkeypatch, tmp_
             {"prompt": "current generation prompt", "date": "2026-08-05", "model": "gpt-image-2"},
         )
     ]
+
+def test_auto_push_ignores_external_urls_without_spawning_network(monkeypatch):
+    configure(monkeypatch)
+    spawned: list[tuple] = []
+    monkeypatch.setattr(push, "_spawn_thread", lambda target, name: spawned.append((target, name)) or None)
+    push.auto_push_gallery_urls([
+        "https://evil.invalid/images/old.png",
+        "file:///etc/passwd",
+        "https://app.invalid/images/unregistered.png",
+    ])
+    assert spawned == []
+
+def test_legacy_registered_local_item_without_flags_is_readable(monkeypatch, tmp_path: Path):
+    index_file = tmp_path / "image_index.json"
+    index_file.write_text(json.dumps({"items": {"legacy.png": {"storage": "local"}}}), encoding="utf-8")
+    image_root = tmp_path / "images"
+    image_root.mkdir()
+    payload = png_bytes()
+    (image_root / "legacy.png").write_bytes(payload)
+    monkeypatch.setattr(config_module, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(storage_module, "DATA_DIR", tmp_path)
+    service = storage_module.ImageStorageService(index_file=index_file)
+    assert service.get_bytes("legacy.png") == payload

--- a/tests/test_genbox_push_followup.py
+++ b/tests/test_genbox_push_followup.py
@@ -105,10 +105,11 @@ def test_unconfigured_push_makes_zero_network_requests(monkeypatch):
     assert calls == []
 
 
-def test_registered_gallery_push_carries_metadata_and_retains_source(monkeypatch):
+def test_registered_gallery_push_carries_metadata_and_retains_source(monkeypatch, tmp_path: Path):
     configure(monkeypatch)
-    payload = png_bytes()
-    monkeypatch.setattr(push.image_storage_service, "get_bytes", lambda rel: payload)
+    service, image_path = registered_storage(monkeypatch, tmp_path)
+    monkeypatch.setattr(push, "image_storage_service", service)
+    payload = image_path.read_bytes()
     monkeypatch.setattr(
         push.image_storage_service,
         "record_genbox_push",
@@ -127,7 +128,7 @@ def test_registered_gallery_push_carries_metadata_and_retains_source(monkeypatch
     )
     monkeypatch.setattr(push.requests, "Session", lambda **kwargs: session)
     result = push.push_gallery_image(
-        "generated.png",
+        "registered.png",
         metadata={"prompt": "a red square", "date": "2026-08-05", "created_at": "2026-08-05T10:00:00Z", "model": "gpt-image-2"},
     )
     post = next(call for call in calls if call[0] == "post")
@@ -142,6 +143,8 @@ def test_registered_gallery_push_carries_metadata_and_retains_source(monkeypatch
     assert post[2]["headers"]["X-GenBox-Key"] == "test-secret"
     assert "test-secret" not in json.dumps(result)
     assert result["source_retained"] is True
+    assert image_path.is_file()
+    assert image_path.read_bytes() == payload
 
 
 @pytest.mark.parametrize("bad_path", ["missing.png", "../outside.png", "/absolute.png", "folder", "note.txt"])

--- a/tests/test_genbox_push_followup.py
+++ b/tests/test_genbox_push_followup.py
@@ -133,7 +133,7 @@ def test_registered_gallery_push_carries_metadata_and_retains_source(monkeypatch
     )
     post = next(call for call in calls if call[0] == "post")
     assert post[2]["data"] == {
-        "remote_path": "generated.png",
+        "remote_path": "registered.png",
         "source_sha256": sha,
         "prompt": "a red square",
         "created_at": "2026-08-05T10:00:00Z",

--- a/tests/test_genbox_push_followup.py
+++ b/tests/test_genbox_push_followup.py
@@ -128,7 +128,7 @@ def test_registered_gallery_push_carries_metadata_and_retains_source(monkeypatch
     monkeypatch.setattr(push.requests, "Session", lambda **kwargs: session)
     result = push.push_gallery_image(
         "generated.png",
-        metadata={"prompt": "a red square", "created_at": "2026-08-05T10:00:00Z", "model": "gpt-image-2"},
+        metadata={"prompt": "a red square", "date": "2026-08-05", "created_at": "2026-08-05T10:00:00Z", "model": "gpt-image-2"},
     )
     post = next(call for call in calls if call[0] == "post")
     assert post[2]["data"] == {
@@ -136,6 +136,7 @@ def test_registered_gallery_push_carries_metadata_and_retains_source(monkeypatch
         "source_sha256": sha,
         "prompt": "a red square",
         "created_at": "2026-08-05T10:00:00Z",
+        "date": "2026-08-05",
         "model": "gpt-image-2",
     }
     assert post[2]["headers"]["X-GenBox-Key"] == "test-secret"
@@ -249,7 +250,7 @@ def test_studio_task_passes_only_result_urls_and_real_metadata(monkeypatch, tmp_
     service = image_tasks.ImageTaskService(
         tmp_path / "tasks.json",
         generation_handler=lambda payload: {
-            "created": 1722852000,
+            "date": "2026-08-05",
             "data": [{"url": "http://app.invalid/images/current.png"}],
             "_image_urls": ["http://app.invalid/images/current.png"],
         },
@@ -271,6 +272,6 @@ def test_studio_task_passes_only_result_urls_and_real_metadata(monkeypatch, tmp_
     assert captured == [
         (
             ["http://app.invalid/images/current.png"],
-            {"prompt": "current generation prompt", "created_at": 1722852000, "model": "gpt-image-2"},
+            {"prompt": "current generation prompt", "date": "2026-08-05", "model": "gpt-image-2"},
         )
     ]

--- a/tests/test_genbox_push_followup.py
+++ b/tests/test_genbox_push_followup.py
@@ -19,6 +19,7 @@ os.environ.setdefault("CHATGPT2API_AUTH_KEY", "unit-test-auth-key")
 import services.genbox_push_service as push
 import services.image_storage_service as storage_module
 import services.config as config_module
+import services.image_task_service as image_tasks
 
 
 class FakeResponse:
@@ -195,3 +196,42 @@ def test_receipt_and_http_errors_keep_source(monkeypatch, response: FakeResponse
 def test_external_url_is_not_eligible_for_studio_auto_push(monkeypatch):
     configure(monkeypatch)
     assert push._rel_from_stored_url("https://evil.invalid/images/old.png") is None
+
+
+def test_studio_task_passes_only_result_urls_and_real_metadata(monkeypatch, tmp_path: Path):
+    captured: list[tuple[list[str], dict[str, object]]] = []
+    monkeypatch.setattr(
+        image_tasks,
+        "auto_push_gallery_urls",
+        lambda urls, *, metadata=None: captured.append((urls, dict(metadata or {}))),
+    )
+    monkeypatch.setattr(image_tasks.realtime_monitor_service, "start", lambda *args, **kwargs: None)
+    monkeypatch.setattr(image_tasks.realtime_monitor_service, "stage", lambda *args, **kwargs: None)
+    service = image_tasks.ImageTaskService(
+        tmp_path / "tasks.json",
+        generation_handler=lambda payload: {
+            "created": 1722852000,
+            "data": [{"url": "http://app.invalid/images/current.png"}],
+            "_image_urls": ["http://app.invalid/images/current.png"],
+        },
+    )
+    key = "owner:task"
+    service._tasks[key] = {"id": "task", "owner_id": "owner", "status": "queued"}
+    monkeypatch.setattr(service, "_log_call", lambda *args, **kwargs: None)
+    import time
+
+    service._run_task(
+        key,
+        "generate",
+        {"prompt": "current generation prompt"},
+        {"id": "owner", "name": "unit", "role": "admin"},
+        "gpt-image-2",
+        time.time(),
+        time.perf_counter(),
+    )
+    assert captured == [
+        (
+            ["http://app.invalid/images/current.png"],
+            {"prompt": "current generation prompt", "created_at": 1722852000, "model": "gpt-image-2"},
+        )
+    ]

--- a/tests/test_genbox_push_followup.py
+++ b/tests/test_genbox_push_followup.py
@@ -213,27 +213,26 @@ def test_timeout_keeps_registered_source_bytes_on_disk(monkeypatch, tmp_path: Pa
 
 
 @pytest.mark.parametrize(
-    "response, expected_code",
+    "post_payload, post_status, expected_code",
     [
-        (FakeResponse(200, {"ok": True, "contract_version": "v1", "source_id": "test-source", "max_image_bytes": 999}), "genbox_invalid_receipt"),
-        (FakeResponse(500, {"error": "bad"}), "genbox_rejected"),
+        ({"ok": True, "contract_version": "v1", "source_id": "test-source", "sha256": "0" * 64, "status": "imported"}, 200, "genbox_invalid_receipt"),
+        ({"error": "bad"}, 500, "genbox_rejected"),
     ],
 )
-def test_receipt_and_http_errors_keep_source(monkeypatch, response: FakeResponse, expected_code: str):
+def test_receipt_and_http_errors_keep_source(monkeypatch, tmp_path: Path, post_payload: dict[str, object], post_status: int, expected_code: str):
     configure(monkeypatch)
-    payload = png_bytes()
-    monkeypatch.setattr(push.image_storage_service, "get_bytes", lambda rel: payload)
-    probe = FakeResponse(200, {"ok": True, "contract_version": "v1", "source_id": "test-source", "max_image_bytes": len(payload)})
-    if response.status_code == 200:
-        import hashlib
-
-        response = FakeResponse(200, {"ok": True, "contract_version": "v1", "source_id": "test-source", "sha256": "0" * 64, "status": "imported"})
+    service, image_path = registered_storage(monkeypatch, tmp_path)
+    monkeypatch.setattr(push, "image_storage_service", service)
+    original = image_path.read_bytes()
+    probe = FakeResponse(200, {"ok": True, "contract_version": "v1", "source_id": "test-source", "max_image_bytes": len(original)})
     calls: list[tuple] = []
-    monkeypatch.setattr(push.requests, "Session", lambda **kwargs: FakeSession([probe, response], calls))
+    monkeypatch.setattr(push.requests, "Session", lambda **kwargs: FakeSession([probe, FakeResponse(post_status, post_payload)], calls))
     with pytest.raises(HTTPException) as exc:
-        push.push_gallery_image("generated.png")
+        push.push_gallery_image("registered.png")
     assert exc.value.detail["error"] == expected_code
     assert calls[0][0] == "get"
+    assert image_path.is_file()
+    assert image_path.read_bytes() == original
 
 
 def test_external_url_is_not_eligible_for_studio_auto_push(monkeypatch):
@@ -301,3 +300,9 @@ def test_legacy_registered_local_item_without_flags_is_readable(monkeypatch, tmp
     monkeypatch.setattr(storage_module, "DATA_DIR", tmp_path)
     service = storage_module.ImageStorageService(index_file=index_file)
     assert service.get_bytes("legacy.png") == payload
+
+
+def test_has_local_rejects_unregistered_path(monkeypatch, tmp_path: Path):
+    service, _ = registered_storage(monkeypatch, tmp_path)
+    assert service.has_local("registered.png") is True
+    assert service.has_local("unregistered.png") is False

--- a/tests/test_genbox_push_followup.py
+++ b/tests/test_genbox_push_followup.py
@@ -63,6 +63,19 @@ def png_bytes() -> bytes:
     return output.getvalue()
 
 
+def registered_storage(monkeypatch, tmp_path: Path, rel: str = "registered.png"):
+    index_file = tmp_path / "image_index.json"
+    index_file.write_text(json.dumps({"items": {rel: {"local": True}}}), encoding="utf-8")
+    image_root = tmp_path / "images"
+    image_root.mkdir()
+    image_path = image_root / rel
+    image_path.parent.mkdir(parents=True, exist_ok=True)
+    image_path.write_bytes(png_bytes())
+    monkeypatch.setattr(config_module, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(storage_module, "DATA_DIR", tmp_path)
+    return storage_module.ImageStorageService(index_file=index_file), image_path
+
+
 def configure(monkeypatch, *, enabled: bool = True):
     settings = {
         "enabled": enabled,
@@ -167,6 +180,32 @@ def test_push_timeout_returns_error_without_delete(monkeypatch):
     assert exc.value.detail["error"] == "genbox_request_failed"
     assert calls[0][0] == "get"
     assert all(call[0] != "delete" for call in calls)
+
+
+def test_push_uses_gallery_registration_before_network(monkeypatch, tmp_path: Path):
+    configure(monkeypatch)
+    service, _ = registered_storage(monkeypatch, tmp_path)
+    monkeypatch.setattr(push, "image_storage_service", service)
+    calls: list[tuple] = []
+    monkeypatch.setattr(push.requests, "Session", lambda **kwargs: calls.append(("session",)) or None)
+    with pytest.raises(HTTPException) as exc:
+        push.push_gallery_image("unregistered.png")
+    assert exc.value.status_code == 404
+    assert calls == []
+
+
+def test_timeout_keeps_registered_source_bytes_on_disk(monkeypatch, tmp_path: Path):
+    configure(monkeypatch)
+    service, image_path = registered_storage(monkeypatch, tmp_path)
+    monkeypatch.setattr(push, "image_storage_service", service)
+    original = image_path.read_bytes()
+    calls: list[tuple] = []
+    monkeypatch.setattr(push.requests, "Session", lambda **kwargs: TimeoutSession(calls))
+    with pytest.raises(HTTPException) as exc:
+        push.push_gallery_image("registered.png")
+    assert exc.value.detail["error"] == "genbox_request_failed"
+    assert image_path.is_file()
+    assert image_path.read_bytes() == original
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Follow-up to the merged GenBox Push work (#17, #18), based on current upstream `main`.

## Changes

- Gallery reads (`get_bytes`, `has_local`, zip download) require a registered Gallery index entry before touching local/WebDAV bytes. Path normalization alone is no longer an authorization boundary.
- Manual and auto Push resolve sources only through Gallery-registered records; missing records, unregistered paths, traversal, absolute paths, directories, and non-image files are rejected before any GenBox request.
- Studio auto Push only processes URLs collected from the current generation result. External origins are rejected.
- Push requests carry `remote_path`, `source_sha256`, and, when present in the real generation record, `prompt`, `created_at`/`date`, and `model`. Missing fields are never fabricated.
- Timeout, HTTP errors, and invalid receipts preserve the source image.
- This PR adds no cleanup, deletion, batch Push, scheduled tasks, or retry-queue behavior; it adapts the existing queue runner to forward generation metadata.

## Verification

- `python -m pytest -q` -> 20 passed
- `git diff --check` clean
- Frontend runtime/build remain blocked by upstream baseline issues (package-lock mismatch for picomatch; icons check), unrelated to this change.
- GenBox behavior is covered with local mocks only; no real GenBox or VPS validation was performed.