### PR TITLE
feat: add receipt-gated source cleanup choice to GenBox Push

### DIFF
--- a/api/gallery_contract.py
+++ b/api/gallery_contract.py
@@ -49,6 +49,7 @@ class GalleryGenBoxPushRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     path: str = Field(min_length=1, max_length=1024)
+    delete_source_after_push: bool = False
 
 
 class GalleryGenBoxPushResult(GalleryGenBoxPushState):

--- a/api/system.py
+++ b/api/system.py
@@ -328,7 +328,11 @@ def create_router(app_version: str) -> APIRouter:
     ):
         require_admin(authorization)
         try:
-            return await run_in_threadpool(push_gallery_image, body.path)
+            return await run_in_threadpool(
+                push_gallery_image,
+                body.path,
+                delete_source_after_push=body.delete_source_after_push,
+            )
         except GenBoxPushError as exc:
             raise HTTPException(
                 status_code=exc.status_code,

--- a/services/config.py
+++ b/services/config.py
@@ -58,6 +58,7 @@ DEFAULT_GENBOX_PUSH = {
     "push_key": "",
     "timeout_secs": 20,
     "auto_push_after_studio": False,
+    "delete_source_after_push": False,
 }
 
 DEFAULT_CHAT_COMPLETION_CACHE = {
@@ -220,6 +221,7 @@ def _normalize_genbox_push_settings(value: object) -> dict[str, object]:
         "push_key": str(source.get("push_key") or "").strip(),
         "timeout_secs": max(5, min(120, timeout)),
         "auto_push_after_studio": _normalize_bool(source.get("auto_push_after_studio"), False),
+        "delete_source_after_push": _normalize_bool(source.get("delete_source_after_push"), False),
     })
     return normalized
 

--- a/services/genbox_push_service.py
+++ b/services/genbox_push_service.py
@@ -140,7 +140,11 @@ def shutdown_genbox_push_service() -> None:
 
 def _run_auto_push(rel: str, *, metadata: Mapping[str, Any] | None = None) -> None:
     try:
-        push_gallery_image(rel, metadata=metadata)
+        push_gallery_image(
+            rel,
+            metadata=metadata,
+            delete_source_after_push=bool((_auto_push_settings() or {}).get("delete_source_after_push")),
+        )
         logger.info({"event": "genbox_auto_push_succeeded", "path": rel})
     except GenBoxPushError as exc:
         logger.warning({"event": "genbox_auto_push_failed", "path": rel, "code": exc.code})
@@ -230,7 +234,12 @@ def _validate_receipt(value: Mapping[str, Any], source_id: str, sha256: str) -> 
     return str(status)
 
 
-def push_gallery_image(relative_path: str, *, metadata: Mapping[str, Any] | None = None) -> dict[str, object]:
+def push_gallery_image(
+    relative_path: str,
+    *,
+    metadata: Mapping[str, Any] | None = None,
+    delete_source_after_push: bool = False,
+) -> dict[str, object]:
     settings = _settings()
     rel = normalize_image_relative_path(relative_path)
     payload = image_storage_service.get_bytes(rel)
@@ -284,4 +293,11 @@ def push_gallery_image(relative_path: str, *, metadata: Mapping[str, Any] | None
     projected = genbox_push_state(state)
     if projected is None:
         raise RuntimeError("stored GenBox push state is invalid")
-    return {"path": rel, **projected, "source_retained": True}
+    safe_to_delete = bool(delete_source_after_push and _json_object(response).get("safe_to_delete_source") is True)
+    removed = False
+    if safe_to_delete and status in {"imported", "already-imported"}:
+        current_payload = image_storage_service.get_bytes(rel)
+        if hashlib.sha256(current_payload).hexdigest() != sha256:
+            return {"path": rel, **projected, "source_retained": True}
+        removed = image_storage_service.delete(rel)
+    return {"path": rel, **projected, "source_retained": not removed}

--- a/web-vue/src/api/gallery.ts
+++ b/web-vue/src/api/gallery.ts
@@ -177,8 +177,9 @@ export const galleryApi = {
   cleanupExpired: () =>
     apiClient.post<never, GalleryCleanupResult>('/api/images/retention-cleanup'),
 
-  pushToGenBox: (path: string) =>
-    apiClient.post<{ path: string }, GalleryGenBoxPushResult>('/api/images/genbox-push', {
+  pushToGenBox: (path: string, deleteSourceAfterPush = false) =>
+    apiClient.post<{ path: string; delete_source_after_push: boolean }, GalleryGenBoxPushResult>('/api/images/genbox-push', {
       path,
+      delete_source_after_push: deleteSourceAfterPush,
     }),
 }

--- a/web-vue/src/types/api.ts
+++ b/web-vue/src/types/api.ts
@@ -61,6 +61,7 @@ export interface SettingsGenBoxPush {
   has_push_key: boolean
   timeout_secs: number
   auto_push_after_studio: boolean
+  delete_source_after_push: boolean
 }
 
 export interface Settings {

--- a/web-vue/src/views/gallery/galleryOperationsRuntime.ts
+++ b/web-vue/src/views/gallery/galleryOperationsRuntime.ts
@@ -14,7 +14,8 @@ type ConfirmDialog = {
     message: string
     confirmText?: string
     cancelText?: string
-  }) => Promise<boolean>
+    checkboxLabel?: string
+  }) => Promise<boolean | { confirmed: boolean; checked: boolean }>
 }
 
 type Toast = {
@@ -263,7 +264,16 @@ export function useGalleryOperationsRuntime(options: GalleryOperationsRuntimeOpt
     if (genboxPushBusyPath.value) return
     genboxPushBusyPath.value = file.path
     try {
-      const result = await galleryApi.pushToGenBox(file.path)
+      const confirmed = await options.confirmDialog.ask({
+        title: '推送到 GenBox',
+        message: '只有你勾选下方选项、且 GenBox 回执确认时，源图才会被删除。',
+        confirmText: '开始推送',
+        cancelText: '取消',
+        checkboxLabel: '推送成功后删除源图（默认不删）',
+      })
+      const selected = typeof confirmed === 'object' && confirmed.confirmed && confirmed.checked
+      if (confirmed === false || (typeof confirmed === 'object' && !confirmed.confirmed)) return
+      const result = await galleryApi.pushToGenBox(file.path, Boolean(selected))
       options.toast.success(result.label, 'Push 成功')
       await options.loadGallery()
     } catch (error) {

--- a/web-vue/src/views/settings/SettingsIntegrationsPanel.vue
+++ b/web-vue/src/views/settings/SettingsIntegrationsPanel.vue
@@ -17,6 +17,16 @@
                 </Checkbox>
               </div>
             </div>
+            <div class="settings-check-item">
+              <div class="settings-check-control">
+                <Checkbox
+                  v-model="settings.genbox_push.delete_source_after_push"
+                  :disabled="!settings.genbox_push.enabled || fieldReadOnly('genbox_push.delete_source_after_push')"
+                >
+                  自动推送成功后删除源图（需 GenBox 回执确认）
+                </Checkbox>
+              </div>
+            </div>
           </div>
           <FormField label="无限画布地址">
             <Input


### PR DESCRIPTION
## Summary

- Add an explicit per-action source-delete choice to the Gallery GenBox Push flow.
- Keep deletion disabled by default.
- Delete only after a successful imported or lready-imported receipt with safe_to_delete_source=true and a fresh local SHA-256 match.
- Add the same opt-in setting to Studio auto-push.

## Safety

- Failed, rejected, mismatched, or ungranted receipts retain the source image.
- The original yukkcat repository is unchanged; this PR is based on yukkcat main and contains one focused commit.
- No real credentials, deployment addresses, or user media are included.

## Verification

- Python syntax check passed for changed backend files.
- 
pm run build passed in web-vue (TypeScript + Vite).

## Scope

This PR follows the existing yukkcat GenBox Push architecture. It does not introduce the unrelated batch/scheduler implementation from another branch.